### PR TITLE
UPD: modified setup and teardown to use their appropriate custom fields

### DIFF
--- a/fmfexporter/adapters/polarion/polarion_test_case.py
+++ b/fmfexporter/adapters/polarion/polarion_test_case.py
@@ -2,8 +2,13 @@ from fmfexporter import FMFTestCase
 import re
 import xml.etree.ElementTree as etree
 from xml.dom import minidom
-
+from html import escape
 from fmfexporter.adapters.polarion.utils.polarion_xml import PolarionXmlUtils
+
+# Static styles to be used while rendering HTML tables
+HTML_TABLE_TD_STYLE = 'height: 12px;text-align: left;vertical-align: top;line-height: 18px;border: 1px solid #CCCCCC;padding: 5px;'
+HTML_TABLE_TH_STYLE = 'white-space: nowrap; height: 12px;text-align: left;vertical-align: top;font-weight: bold;background-color: #F0F0F0;border: 1px solid #CCCCCC;padding: 5px;width: 50%;'
+HTML_TABLE_STYLE = 'margin: auto;empty-cells: show;border-collapse: collapse;border: 1px solid #CCCCCC;width:80%;'
 """
 Representation of a Polarion Test Case XML.
 """
@@ -225,6 +230,8 @@ class PolarionTestCase(object):
         PolarionXmlUtils.new_custom_field(tc_custom, 'caseimportance', self.importance)
         PolarionXmlUtils.new_custom_field(tc_custom, 'caseposneg', self.positive)
         PolarionXmlUtils.new_custom_field(tc_custom, 'caseautomation', self.automated)
+        PolarionXmlUtils.new_custom_field(tc_custom, 'setup', self.create_step_result_table(self.setup))
+        PolarionXmlUtils.new_custom_field(tc_custom, 'teardown', self.create_step_result_table(self.teardown))
 
         # testcase/linked-work-items
         if self.verifies:
@@ -235,14 +242,8 @@ class PolarionTestCase(object):
                                                       'verifies')
 
         # testcase/test-steps
-        if self.steps or self.setup or self.teardown:
+        if self.steps:
             tc_steps = etree.SubElement(tc, 'test-steps')
-
-            for step in self.setup:
-                PolarionXmlUtils.new_test_step(tc_steps, "(setup) #. {}".format(step.step), step.result)
-
-            for step in self.teardown:
-                PolarionXmlUtils.new_test_step(tc_steps, "(teardown) #. {}".format(step.step), step.result)
 
             # If test case has parameters, add them
             if self.parameters:
@@ -254,3 +255,27 @@ class PolarionTestCase(object):
         xml_str = minidom.parseString(etree.tostring(xmlroot)).toprettyxml()
 
         return xml_str
+
+    def create_step_result_table(self, steps):
+        """
+        Generates an HTML table (same style used by Polarion in Test Steps table).
+        Provided steps (array) must contain a "step" and "result" attributes.
+        :param steps:
+        :return:
+        """
+        if not steps:
+            return None
+
+        setup_content = ('<table style="' + HTML_TABLE_STYLE + '"><tbody>')
+        setup_content += ('<tr><th style="' + HTML_TABLE_TH_STYLE + '" contenteditable="false">Step</th>')
+        setup_content += ('<th style="' + HTML_TABLE_TH_STYLE + '" contenteditable="false">Expected Result</th></tr>')
+        for step in steps:
+            setup_content += '<tr><td style="{}">(setup) #. {}</td>'.format(
+                HTML_TABLE_TD_STYLE,
+                escape(step.step).replace('\n', '<br>'))
+            setup_content += '<td style="{}">{}</td></tr>'.format(
+                HTML_TABLE_TD_STYLE,
+                escape(step.result).replace('\n', '<br>'))
+        setup_content += '</tbody></table>'
+
+        return setup_content


### PR DESCRIPTION
The setup and teardown elements are defined in Polarion as "custom-fields" and so they are supposed to be populated with "text/html".

The HTML table generation is using static styling (same used in test steps table). See if looks good to you and merge it to your own branch. After that ping me and I will merge to devel.