### PR TITLE
Redirect logger to stdout and handle invalit project ID properly

### DIFF
--- a/bin/fmfexporter
+++ b/bin/fmfexporter
@@ -30,7 +30,7 @@ if __name__ == '__main__':
 
     # Initialize logging
     logging.basicConfig(level=logging.getLevelName(parsed.log_level),
-                        format='%(asctime)s [%(levelname)s] (%(pathname)s:%(lineno)s) - %(message)s')
+                        format='%(asctime)s [%(levelname)s] (%(name)s:%(lineno)s) - %(message)s')
 
     # Filtering FMF Tree according to common arguments
     adapter: FMFAdapter = argparser.adapter

--- a/bin/fmfexporter
+++ b/bin/fmfexporter
@@ -29,8 +29,7 @@ if __name__ == '__main__':
     parsed = argparser.parse_args()
 
     # Initialize logging
-    logging.basicConfig(filename="fmfexporter.log",
-                        level=logging.getLevelName(parsed.log_level),
+    logging.basicConfig(level=logging.getLevelName(parsed.log_level),
                         format='%(asctime)s [%(levelname)s] (%(pathname)s:%(lineno)s) - %(message)s')
 
     # Filtering FMF Tree according to common arguments

--- a/fmfexporter/adapters/polarion/polarion_reporter.py
+++ b/fmfexporter/adapters/polarion/polarion_reporter.py
@@ -59,7 +59,6 @@ class PolarionReporter(object):
         except RequestException as req_ex:
             err_msg = "Error submitting test case: %s" % req_ex
             LOGGER.error(err_msg)
-            print(err_msg)
             raise req_ex
 
         LOGGER.debug("HTTP Response [Code: %s]: %s" % (response.status_code, response.content))
@@ -159,7 +158,6 @@ class PolarionReporter(object):
         """
         tc_job_url = "%s (ID: %s)" % (tc_job_url, tc_id)
         LOGGER.info(tc_job_url)
-        print(tc_job_url)
 
     @staticmethod
     def to_xml(polarion_testcase_list: list):
@@ -275,7 +273,6 @@ class PolarionReporter(object):
             except RequestException as req_ex:
                 err_msg = "Error getting response from import job: %s" % req_ex
                 LOGGER.error(err_msg)
-                print(err_msg)
                 raise req_ex
 
             if response.status_code != 200 or "Project id not specified or invalid" in response.content.decode('utf-8'):

--- a/fmfexporter/adapters/polarion/polarion_reporter.py
+++ b/fmfexporter/adapters/polarion/polarion_reporter.py
@@ -157,7 +157,7 @@ class PolarionReporter(object):
         :param tc_id:
         """
         for url in tc_job_urls:
-            tc_job_url = "%s" % (url)
+            tc_job_url = "Reporting job url: %s" % (url)
             LOGGER.info(tc_job_url)
 
     @staticmethod

--- a/fmfexporter/adapters/polarion/polarion_reporter.py
+++ b/fmfexporter/adapters/polarion/polarion_reporter.py
@@ -92,12 +92,11 @@ class PolarionReporter(object):
         except RequestException as req_ex:
             err_msg = "Error submitting test case: %s" % req_ex
             LOGGER.error(err_msg)
-            print(err_msg)
             raise req_ex
 
         LOGGER.debug("HTTP Response [Code: %s]: %s" % (response.status_code, response.content))
 
-        if response.status_code != 200:
+        if response.status_code != 200 or "Project id not specified or invalid" in response.content:
             raise Exception('Error submitting test-case to Polarion: %s' % response.content)
         else:
             submitted_tc.extend(self.handle_response(response, testcases, parse_response))

--- a/fmfexporter/adapters/polarion/polarion_reporter.py
+++ b/fmfexporter/adapters/polarion/polarion_reporter.py
@@ -150,14 +150,15 @@ class PolarionReporter(object):
         tc_job_url = "%s-log?jobId=%s" % (self.config.test_case_url(), job_id)
         return tc_job_url
 
-    def print_tc_job_url(self, tc_job_url: str, tc_id: str):
+    def print_tc_job_urls(self, tc_job_urls: list):
         """
         Print the statically generated URL for submitted job id.
         :param tc_job_url:
         :param tc_id:
         """
-        tc_job_url = "%s (ID: %s)" % (tc_job_url, tc_id)
-        LOGGER.info(tc_job_url)
+        for url in tc_job_urls:
+            tc_job_url = "%s" % (url)
+            LOGGER.info(tc_job_url)
 
     @staticmethod
     def to_xml(polarion_testcase_list: list):
@@ -323,13 +324,12 @@ class PolarionReporter(object):
             # We don't track testcase vs import job mapping (multiple import xml files).
             # All testcases submitted by this execution are imported from 1 xml file.
             raise RuntimeError("Error occurred when importing testcase! Multiple job urls found.")
-        else:
-            job_url = urls[0]
 
         for testcase in testcases:
-            self.print_tc_job_url(job_url, testcase.id)
             tcs.append(testcase)
 
+        self.print_tc_job_urls(urls)
+
         if parse_response:
-            self.parse_import_job_data(job_url, testcases)
+            self.parse_import_job_data(urls, testcases)
         return tcs

--- a/fmfexporter/adapters/polarion/polarion_reporter.py
+++ b/fmfexporter/adapters/polarion/polarion_reporter.py
@@ -64,7 +64,7 @@ class PolarionReporter(object):
 
         LOGGER.debug("HTTP Response [Code: %s]: %s" % (response.status_code, response.content))
 
-        if response.status_code != 200:
+        if response.status_code != 200 or "Project id not specified or invalid" in response.content.decode('utf-8'):
             raise Exception('Error submitting test-case to Polarion: %s' % response.content)
         else:
             submitted_tc.extend(self.handle_response(response, [testcase], parse_response))
@@ -96,7 +96,7 @@ class PolarionReporter(object):
 
         LOGGER.debug("HTTP Response [Code: %s]: %s" % (response.status_code, response.content))
 
-        if response.status_code != 200 or "Project id not specified or invalid" in response.content:
+        if response.status_code != 200 or "Project id not specified or invalid" in response.content.decode('utf-8'):
             raise Exception('Error submitting test-case to Polarion: %s' % response.content)
         else:
             submitted_tc.extend(self.handle_response(response, testcases, parse_response))
@@ -278,7 +278,7 @@ class PolarionReporter(object):
                 print(err_msg)
                 raise req_ex
 
-            if response.status_code != 200:
+            if response.status_code != 200 or "Project id not specified or invalid" in response.content.decode('utf-8'):
                 raise Exception('Error getting import job data from Polarion: %s' % response.content)
             else:
                 out = response.content.decode("UTF-8")

--- a/fmfexporter/args/args_parser.py
+++ b/fmfexporter/args/args_parser.py
@@ -32,6 +32,7 @@ class FMFExporterArgParser(object):
             "--tc", action="append", help="FMF Test Case filter (by name)")
         self._parser.add_argument(
             "--log-level", choices=['WARNING', 'INFO', 'DEBUG'], default='INFO',
+            # action='store_true', dest='log_level',
             help="Specify logging level to use")
         self._parser.add_argument(
             "--show-scheme", action='store_true', dest='show_scheme',


### PR DESCRIPTION
This PR changes the configuration of logger. Currently, all log messages are stored in the files, which is not friendly in case you execute the exporter in the container, which is destroyed after the cmd execution. With this change, all log messages will be available in the console.

This PR also improves handling of `Project id not specified or invalid` error, which has error code 200 from Polarion API.