### PR TITLE
Write polarion xml into file everytime

### DIFF
--- a/fmfexporter/adapters/polarion/polarion_reporter.py
+++ b/fmfexporter/adapters/polarion/polarion_reporter.py
@@ -45,7 +45,6 @@ class PolarionReporter(object):
         :return:
         """
         xml = testcase.to_xml()
-        LOGGER.debug(xml)
 
         xml_file = {'file': ('testcase.xml', xml)}
         submitted_tc = []
@@ -78,7 +77,6 @@ class PolarionReporter(object):
         :return:
         """
         xml = PolarionReporter.to_xml(testcases)
-        LOGGER.debug(xml)
 
         xml_file = {'file': ('testcase.xml', xml)}
         submitted_tc = []

--- a/fmfexporter/adapters/polarion/polarion_reporter.py
+++ b/fmfexporter/adapters/polarion/polarion_reporter.py
@@ -253,6 +253,12 @@ class PolarionReporter(object):
 
         xml_str = minidom.parseString(etree.tostring(xmlroot)).toprettyxml()
 
+        output_file_name = "testcase.xml"
+        LOGGER.info("Generated: %s", output_file_name)
+        with open(output_file_name, 'w') as out_file:
+            out_file.write(xml_str)
+            out_file.close()
+
         return xml_str
 
     def parse_import_job_data(self, import_job_url: list, testcases):

--- a/fmfexporter/adapters/polarion/polarion_test_case.py
+++ b/fmfexporter/adapters/polarion/polarion_test_case.py
@@ -295,6 +295,10 @@ class PolarionTestCase(object):
 
         xml_str = minidom.parseString(etree.tostring(xmlroot)).toprettyxml()
 
+        with open("testcase.xml", 'w') as out_file:
+            out_file.write(xml_str)
+            out_file.close()
+
         return xml_str
 
     def create_step_result_table(self, steps):


### PR DESCRIPTION
This PR adds functionality that will save fmfexporter output XML to file for every imported bunch of test cases. It also removes some logs which make the console log a little bit messy.